### PR TITLE
Update of pure python version of SeeMPS with last version of the project

### DIFF
--- a/seemps/mpo.py
+++ b/seemps/mpo.py
@@ -211,6 +211,8 @@ class MPO(TensorArray):
             simplify=self.simplify,
             tolerance=self.tolerance,
             normalize=self.normalize,
+            maxsweeps=self.maxsweeps,
+            max_bond_dimension=self.max_bond_dimension,
         )
 
 
@@ -234,7 +236,7 @@ class MPOList(object):
         self,
         mpos,
         simplify=False,
-        maxsweeps=4,
+        maxsweeps=16,
         tolerance=DEFAULT_TOLERANCE,
         normalize=False,
         max_bond_dimension=None,
@@ -386,6 +388,8 @@ class MPOList(object):
             simplify=self.simplify,
             tolerance=self.tolerance,
             normalize=self.normalize,
+            maxsweeps=self.maxsweeps,
+            max_bond_dimension=self.max_bond_dimension,
         )
 
 
@@ -411,7 +415,7 @@ class MPOSum(object):
         mpos,
         weights=None,
         simplify=False,
-        maxsweeps=4,
+        maxsweeps=16,
         tolerance=DEFAULT_TOLERANCE,
         normalize=False,
         max_bond_dimension=None,
@@ -582,4 +586,6 @@ class MPOSum(object):
             simplify=self.simplify,
             tolerance=self.tolerance,
             normalize=self.normalize,
+            maxsweeps=self.maxsweeps,
+            max_bond_dimension=self.max_bond_dimension,
         )

--- a/seemps/state/mps.py
+++ b/seemps/state/mps.py
@@ -442,11 +442,13 @@ class MPSSum:
         the complete wavefunction that is encoded in the MPS."""
         return sum(wa * A.to_vector() for wa, A in zip(self.weights, self.states))
 
-    def toMPS(self, normalize=None):
+    def toMPS(self, normalize=None, tolerance=None):
         from ..truncate.combine import combine
 
         if normalize is None:
             normalize = self.normalize
+        if tolerance is None:
+            tolerance = self.tolerance
         ψ, _ = combine(
             self.weights,
             self.states,

--- a/seemps/truncate/combine.py
+++ b/seemps/truncate/combine.py
@@ -22,11 +22,11 @@ def guess_combine_state(weights, states):
     weighted_states = []
     for i, psi in enumerate(states):
         weighted_states.append(weights[i] * psi)
-    for site in range(states[0].size):
+    for site in range(weighted_states[0].size):
         DL_max = 0
         DR_max = 0
         z = 0
-        for state in states:
+        for state in weighted_states:
             z += state[site][0, 0, 0]
             DL, i, DR = state[site].shape
             if DL > DL_max:
@@ -82,11 +82,13 @@ def combine(
     )
     start = 0 if direction > 0 else guess.size - 1
     φ = CanonicalMPS(guess, center=start, tolerance=tolerance)
-    err = norm_ψsqr = multi_norm_squared(weights, states)
+    φ.maxsweeps = maxsweeps
+    φ.max_bond_dimension = max_bond_dimension
+    norm_ψsqr = multi_norm_squared(weights, states)
     if norm_ψsqr < tolerance:
         return MPS([np.zeros((1, P.shape[1], 1)) for P in φ]), 0
     log(
-        f"COMBINE ψ with |ψ|={norm_ψsqr**0.5} for {maxsweeps} sweeps.\nWeights: {weights}"
+        f"COMBINE ψ with |ψ|={norm_ψsqr**0.5} for {maxsweeps} sweeps with tolerance = {tolerance}.\nWeights: {weights}"
     )
 
     size = φ.size
@@ -124,10 +126,10 @@ def combine(
             norm_φsqr = 1.0
         C = sum(α * f.tensor1site() for α, f in zip(weights, forms))
         scprod_φψ = np.vdot(B, C)
-        old_err = err
+        
         err = 2 * abs(1.0 - scprod_φψ.real / np.sqrt(norm_φsqr * norm_ψsqr))
-        log(f"sweep={sweep}, rel.err.={err}, old err.={old_err}, |φ|={norm_φsqr**0.5}")
-        if err < tolerance or err > old_err:
+        log(f"sweep={sweep}, rel.err.={err}, |φ|={norm_φsqr**0.5}")
+        if err < tolerance:
             log("Stopping, as tolerance reached")
             break
         direction = -direction

--- a/seemps/truncate/simplify.py
+++ b/seemps/truncate/simplify.py
@@ -125,12 +125,13 @@ def simplify(
 
     base_error = ψ.error()
     φ = state.CanonicalMPS(ψ, center=start, tolerance=tolerance, normalize=normalize)
+    φ.maxsweeps = maxsweeps
+    φ.max_bond_dimension = max_bond_dimension
     if max_bond_dimension == 0 and tolerance <= 0:
         return φ
 
     form = AntilinearForm(φ, ψ, center=start)
     norm_ψsqr = scprod(ψ, ψ).real
-    err = 1.0
     log(
         f"SIMPLIFY ψ with |ψ|={norm_ψsqr**0.5} for {maxsweeps} sweeps, with tolerance {tolerance}."
     )
@@ -169,10 +170,9 @@ def simplify(
             φ[last] = B = B / norm_φsqr
             norm_φsqr = 1.0
         scprod_φψ = np.vdot(B, form.tensor1site())
-        old_err = err
         err = 2 * abs(1.0 - scprod_φψ.real / np.sqrt(norm_φsqr * norm_ψsqr))
-        log(f"sweep={sweep}, rel.err.={err}, old err.={old_err}, |φ|={norm_φsqr**0.5}")
-        if err < tolerance or err > old_err:
+        log(f"sweep={sweep}, rel.err.={err}, |φ|={norm_φsqr**0.5}")
+        if err < tolerance:
             log("Stopping, as tolerance reached")
             break
         direction = -direction


### PR DESCRIPTION
1. mpo.py
- Add maxsweeps=self.maxsweeps and max_bond_dimension=self.max_bond_dimension to the new generated MPO, MPOList and MPOSum in the respective new object created with the corresponding extend method.
- Change default maxsweeps from 4 to 16 in MPOList and MPOSum so it is the same as the one for MPO.

2. mps.py
- Add tolerance as argument in toMPS.

3. combine.py
- Iterate over weighted_states instead of states in guess_combine_state.
- Add tolerance in log of combine.
- Add φ.maxsweeps = maxsweeps and φ.max_bond_dimension = max_bond_dimension to the new generated state in combine so the attributes are conserved.
- Remove err < old_err from the convergence condition to avoid inestabilities.

4. simplify.py
- Add φ.maxsweeps = maxsweeps and φ.max_bond_dimension = max_bond_dimension to the new generated state in combine so the attributes are conserved.
- Remove err < old_err from the convergence condition to avoid inestabilities.